### PR TITLE
add symbol to pylint message

### DIFF
--- a/pylava_pylint/main.py
+++ b/pylava_pylint/main.py
@@ -45,7 +45,7 @@ class Linter(BaseLinter):
                 self.errors.append(dict(
                     lnum=msg.line,
                     col=msg.column,
-                    text="%s %s" % (msg.msg_id, msg.msg),
+                    text="%s (%s) %s" % (msg.msg_id, msg.symbol, msg.msg),
                     type=msg.msg_id[0]
                 ))
 


### PR DESCRIPTION
I often have projects, which require to silence pylint messages explicitelly by their symbol.
If we could add this patch, the symbol would appear in the message and it would be quite easy to achieve.